### PR TITLE
Set value for tag 'puppet_cert_signed' to 'true'

### DIFF
--- a/certsigner.rb
+++ b/certsigner.rb
@@ -56,7 +56,7 @@ if signed != true && ami_match == true
     tags: [
       {
         key: 'puppet_cert_signed',
-        value: certname,
+        value: 'true',
       },
     ],
   })


### PR DESCRIPTION
Tag 'puppet_cert_signed' in the certsigner script should be assigned a 'true' value and not 'certname' (which is empty) after signing.
